### PR TITLE
Fail gracefully if tag doesn't exist

### DIFF
--- a/lib/facter/client_id.rb
+++ b/lib/facter/client_id.rb
@@ -1,8 +1,8 @@
 Facter.add(:client_id) do
   setcode do
-    if Facter.value(:az_metadata) != 'unavailable'
+    begin
       Facter.value(:az_metadata)['compute']['tagsList'].select { |k| k['name'] == 'clientId' }[0]['value']
-    else
+    rescue
       'unavailable'
     end
   end


### PR DESCRIPTION
If the tag doesn't exist, the fact fails with an error:

```
irb(main):003:0> Facter.value(:az_metadata)['compute']['tagsList'].select { |k| k['name'] == 'clientId' }[0]['value']
Traceback (most recent call last):
        4: from /opt/puppetlabs/puppet/bin/irb:23:in `<main>'
        3: from /opt/puppetlabs/puppet/bin/irb:23:in `load'
        2: from /opt/puppetlabs/puppet/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        1: from (irb):3
NoMethodError (undefined method `[]' for nil:NilClass)
```

Instead, I wrote code that captures the exception and returns `unavailable`:

```
~ # facter -p new_client_id
unavailable
```